### PR TITLE
Update profile controller image tag

### DIFF
--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -24,7 +24,7 @@ images:
   newTag: vmaster-g9f3bfd00
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-ga49f658f
+  newTag: v1.1.0-ga49f658f
 vars:
 - fieldref:
     fieldPath: data.admin


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
It resolves the namespace issue created by the old profile controller described here https://github.com/kubeflow/kubeflow/issues/5207

**Description of your changes:**
Update to v1.1 https://console.cloud.google.com/gcr/images/kubeflow-images-public/GLOBAL/profile-controller@sha256:370596d3672a60e2e15c5c3c4df436190b0fb34f84aad85406d93c52f7f039b5/details?tab=info

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
